### PR TITLE
Add proguard rule to keep Preference classes

### DIFF
--- a/library/proguard-rules.txt
+++ b/library/proguard-rules.txt
@@ -9,6 +9,8 @@
 
 # Add any project specific keep options here:
 
+-keep public class * extends android.preference.Preference
+
 # If your project uses WebView with JS, uncomment the following
 # and specify the fully qualified class name to the JavaScript interface
 # class:


### PR DESCRIPTION
Needed to avoid that SwitchPreference becomes obfuscated.

See https://github.com/BoD/android-switch-backport/issues/28
