### PR TITLE
Improve proguard rule to keep Preference classes

### DIFF
--- a/library/proguard-rules.txt
+++ b/library/proguard-rules.txt
@@ -9,7 +9,7 @@
 
 # Add any project specific keep options here:
 
--keep public class * extends android.preference.Preference
+-keep public class * extends android.preference.Preference { *; }
 
 # If your project uses WebView with JS, uncomment the following
 # and specify the fully qualified class name to the JavaScript interface


### PR DESCRIPTION
Sorry, did not properly test the Proguard rule for keeping Preference:s. We need to ensure that Proguard does not strip away important members of the class as well, such as constructors. This rule change keeps all members of Preference classes. That's the safest way. 
