### PR TITLE
Prefix all attributes with asb_ to avoid collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ they are now hosted on jcenter. Please update your repository declarations!
 
 ### Using the Switch
 
-Once you have done that, have a theme for your application (or Activity), that declares the `switchStyle` item
+Once you have done that, have a theme for your application (or Activity), that declares the `asb_switchStyle` item
 to be one of the two possible themes: either `Widget.Holo.CompoundButton.Switch` (dark) or `Widget.Holo.Light.CompoundButton.Switch`
 (light).
 
@@ -71,7 +71,7 @@ The simplest way to do that is to create a `themes.xml` file in your project's `
 <resources>
 
     <style name="Theme" parent="@android:style/Theme">
-        <item name="switchStyle">@style/Widget.Holo.CompoundButton.Switch</item>
+        <item name="asb_switchStyle">@style/Widget.Holo.CompoundButton.Switch</item>
     </style>
 
 </resources>
@@ -101,15 +101,15 @@ Then in your layout xml files you use the widget like this:
 
 ### Using the SwitchPreference
 
-Add switchPreferenceStyle to your 'themes.xml'
+Add `asb_switchPreferenceStyle` to your 'themes.xml'
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
     <style name="Theme" parent="@android:style/Theme">
-        <item name="switchStyle">@style/Widget.Holo.CompoundButton.Switch</item>
-        <item name="switchPreferenceStyle">@style/Preference.SwitchPreference</item>
+        <item name="asb_switchStyle">@style/Widget.Holo.CompoundButton.Switch</item>
+        <item name="asb_switchPreferenceStyle">@style/Preference.SwitchPreference</item>
     </style>
 
 </resources>
@@ -124,10 +124,10 @@ Then in your preference xml file:
     <org.jraf.android.backport.switchwidget.SwitchPreference
         android:key="testKey"
         android:title="SwitchPreference Test"
-        switchpref:switchTextOff="@string/off"
-        switchpref:switchTextOn="@string/on"
-        switchpref:summaryOff="@string/summary_off"
-        switchpref:summaryOn="@string/summary_on" />
+        switchpref:asb_switchTextOff="@string/off"
+        switchpref:asb_switchTextOn="@string/on"
+        switchpref:asb_summaryOff="@string/summary_off"
+        switchpref:asb_summaryOn="@string/summary_on" />
 
 </PreferenceScreen>
 ```

--- a/library/res/values/attrs.xml
+++ b/library/res/values/attrs.xml
@@ -32,51 +32,51 @@
              SwitchPreference is checked. If separate on/off summaries are not
              needed, the summary attribute can be used instead.
         -->
-        <attr name="summaryOn" format="reference" />
+        <attr name="asb_summaryOn" format="reference" />
         <!--
              The summary for the Preference in a PreferenceActivity screen when the
              SwitchPreference is unchecked. If separate on/off summaries are not
              needed, the summary attribute can be used instead.
         -->
-        <attr name="summaryOff" format="reference" />
+        <attr name="asb_summaryOff" format="reference" />
         <!--
              The text used on the switch itself when in the "on" state.
              This should be a very SHORT string, as it appears in a small space.
         -->
-        <attr name="switchTextOn" format="reference" />
+        <attr name="asb_switchTextOn" format="reference" />
         <!--
              The text used on the switch itself when in the "off" state.
              This should be a very SHORT string, as it appears in a small space.
         -->
-        <attr name="switchTextOff" format="reference" />
+        <attr name="asb_switchTextOff" format="reference" />
         <!--
              The state (true for on, or false for off) that causes dependents to be disabled. By default,
              dependents will be disabled when this is unchecked, so the value of this preference is false.
         -->
-        <attr name="disableDependentsState" format="boolean" />
+        <attr name="asb_disableDependentsState" format="boolean" />
     </declare-styleable>
     <declare-styleable name="Switch">
 
         <!-- Drawable to use as the "thumb" that switches back and forth. -->
-        <attr name="thumb" format="reference" />
+        <attr name="asb_thumb" format="reference" />
         <!-- Drawable to use as the "track" that the switch thumb slides within. -->
-        <attr name="track" format="reference" />
+        <attr name="asb_track" format="reference" />
         <!-- Text to use when the switch is in the checked/"on" state. -->
-        <attr name="textOn" format="reference" />
+        <attr name="asb_textOn" format="reference" />
         <!-- Text to use when the switch is in the unchecked/"off" state. -->
-        <attr name="textOff" format="reference" />
+        <attr name="asb_textOff" format="reference" />
         <!-- Amount of padding on either side of text within the switch thumb. -->
-        <attr name="thumbTextPadding" format="dimension" />
+        <attr name="asb_thumbTextPadding" format="dimension" />
         <!-- TextAppearance style for text displayed on the switch thumb. -->
-        <attr name="switchTextAppearance" format="reference" />
+        <attr name="asb_switchTextAppearance" format="reference" />
         <!-- Minimum width for the switch component -->
-        <attr name="switchMinWidth" format="dimension" />
+        <attr name="asb_switchMinWidth" format="dimension" />
         <!-- Minimum space between the switch and caption text -->
-        <attr name="switchPadding" format="dimension" />
+        <attr name="asb_switchPadding" format="dimension" />
     </declare-styleable>
     <declare-styleable name="SwitchBackportTheme">
-        <attr name="switchStyle" format="reference" />
-        <attr name="switchPreferenceStyle" format="reference" />
+        <attr name="asb_switchStyle" format="reference" />
+        <attr name="asb_switchPreferenceStyle" format="reference" />
     </declare-styleable>
     <declare-styleable name="Android">
 

--- a/library/res/values/styles.xml
+++ b/library/res/values/styles.xml
@@ -26,32 +26,32 @@
 <resources>
 
     <style name="Widget.Holo.CompoundButton.Switch" parent="android:Widget.CompoundButton">
-        <item name="track">@drawable/switch_track_holo_dark</item>
-        <item name="thumb">@drawable/switch_inner_holo_dark</item>
-        <item name="switchTextAppearance">@style/TextAppearance.Holo.Widget.Switch</item>
-        <item name="textOn">@string/switch_on</item>
-        <item name="textOff">@string/switch_off</item>
-        <item name="thumbTextPadding">12dip</item>
-        <item name="switchMinWidth">96dip</item>
-        <item name="switchPadding">16dip</item>
+        <item name="asb_track">@drawable/switch_track_holo_dark</item>
+        <item name="asb_thumb">@drawable/switch_inner_holo_dark</item>
+        <item name="asb_switchTextAppearance">@style/TextAppearance.Holo.Widget.Switch</item>
+        <item name="asb_textOn">@string/switch_on</item>
+        <item name="asb_textOff">@string/switch_off</item>
+        <item name="asb_thumbTextPadding">12dip</item>
+        <item name="asb_switchMinWidth">96dip</item>
+        <item name="asb_switchPadding">16dip</item>
     </style>
 
     <style name="Widget.Holo.Light.CompoundButton.Switch" parent="android:Widget.CompoundButton">
-        <item name="track">@drawable/switch_track_holo_light</item>
-        <item name="thumb">@drawable/switch_inner_holo_light</item>
-        <item name="switchTextAppearance">@style/TextAppearance.Holo.Light.Widget.Switch</item>
-        <item name="textOn">@string/switch_on</item>
-        <item name="textOff">@string/switch_off</item>
-        <item name="thumbTextPadding">12dip</item>
-        <item name="switchMinWidth">96dip</item>
-        <item name="switchPadding">16dip</item>
+        <item name="asb_track">@drawable/switch_track_holo_light</item>
+        <item name="asb_thumb">@drawable/switch_inner_holo_light</item>
+        <item name="asb_switchTextAppearance">@style/TextAppearance.Holo.Light.Widget.Switch</item>
+        <item name="asb_textOn">@string/switch_on</item>
+        <item name="asb_textOff">@string/switch_off</item>
+        <item name="asb_thumbTextPadding">12dip</item>
+        <item name="asb_switchMinWidth">96dip</item>
+        <item name="asb_switchPadding">16dip</item>
     </style>
 
     <style name="Preference.SwitchPreference" parent="">
         <item name="android:layout">@layout/preference</item>
         <item name="android:widgetLayout">@layout/preference_widget_switch</item>
-        <item name="switchTextOn">@string/switch_on</item>
-        <item name="switchTextOff">@string/switch_off</item>
+        <item name="asb_switchTextOn">@string/switch_on</item>
+        <item name="asb_switchTextOff">@string/switch_off</item>
     </style>
 
     <style name="TextAppearance.Holo.Widget.Switch" parent="android:TextAppearance.Small">

--- a/library/src/org/jraf/android/backport/switchwidget/Switch.java
+++ b/library/src/org/jraf/android/backport/switchwidget/Switch.java
@@ -54,7 +54,7 @@ import android.widget.CompoundButton;
  * whereas the {@link #setTextOff(CharSequence) off} and {@link #setTextOn(CharSequence) on} text
  * controls the text on the thumb. Similarly, the {@link #setTextAppearance(android.content.Context, int) textAppearance} and the related
  * setTypeface() methods control the typeface and style of label text, whereas the {@link #setSwitchTextAppearance(android.content.Context, int)
- * switchTextAppearance} and
+ * asb_switchTextAppearance} and
  * the related seSwitchTypeface() methods control that of the thumb.
  * 
  */
@@ -119,7 +119,7 @@ public class Switch extends CompoundButton {
      * @param attrs Specification of attributes that should deviate from default styling.
      */
     public Switch(Context context, AttributeSet attrs) {
-        this(context, attrs, R.attr.switchStyle);
+        this(context, attrs, R.attr.asb_switchStyle);
     }
 
     /**
@@ -142,15 +142,15 @@ public class Switch extends CompoundButton {
 
         final TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.Switch, defStyle, 0);
 
-        mThumbDrawable = a.getDrawable(R.styleable.Switch_thumb);
-        mTrackDrawable = a.getDrawable(R.styleable.Switch_track);
-        mTextOn = a.getText(R.styleable.Switch_textOn);
-        mTextOff = a.getText(R.styleable.Switch_textOff);
-        mThumbTextPadding = a.getDimensionPixelSize(R.styleable.Switch_thumbTextPadding, 0);
-        mSwitchMinWidth = a.getDimensionPixelSize(R.styleable.Switch_switchMinWidth, 0);
-        mSwitchPadding = a.getDimensionPixelSize(R.styleable.Switch_switchPadding, 0);
+        mThumbDrawable = a.getDrawable(R.styleable.Switch_asb_thumb);
+        mTrackDrawable = a.getDrawable(R.styleable.Switch_asb_track);
+        mTextOn = a.getText(R.styleable.Switch_asb_textOn);
+        mTextOff = a.getText(R.styleable.Switch_asb_textOff);
+        mThumbTextPadding = a.getDimensionPixelSize(R.styleable.Switch_asb_thumbTextPadding, 0);
+        mSwitchMinWidth = a.getDimensionPixelSize(R.styleable.Switch_asb_switchMinWidth, 0);
+        mSwitchPadding = a.getDimensionPixelSize(R.styleable.Switch_asb_switchPadding, 0);
 
-        final int appearance = a.getResourceId(R.styleable.Switch_switchTextAppearance, 0);
+        final int appearance = a.getResourceId(R.styleable.Switch_asb_switchTextAppearance, 0);
         if (appearance != 0) {
             setSwitchTextAppearance(context, appearance);
         }

--- a/library/src/org/jraf/android/backport/switchwidget/SwitchPreference.java
+++ b/library/src/org/jraf/android/backport/switchwidget/SwitchPreference.java
@@ -39,11 +39,11 @@ import android.widget.CompoundButton;
  * <p>
  * This preference will store a boolean into the SharedPreferences.
  * 
- * @attr ref android.R.styleable#SwitchPreference_summaryOff
- * @attr ref android.R.styleable#SwitchPreference_summaryOn
- * @attr ref android.R.styleable#SwitchPreference_switchTextOff
- * @attr ref android.R.styleable#SwitchPreference_switchTextOn
- * @attr ref android.R.styleable#SwitchPreference_disableDependentsState
+ * @attr ref android.R.styleable#SwitchPreference_asb_summaryOff
+ * @attr ref android.R.styleable#SwitchPreference_asb_summaryOn
+ * @attr ref android.R.styleable#SwitchPreference_asb_switchTextOff
+ * @attr ref android.R.styleable#SwitchPreference_asb_switchTextOn
+ * @attr ref android.R.styleable#SwitchPreference_asb_disableDependentsState
  */
 public class SwitchPreference extends TwoStatePreference {
 	// Switch text for on and off states
@@ -80,14 +80,14 @@ public class SwitchPreference extends TwoStatePreference {
 		super(context, attrs, defStyle);
 
 		TypedArray a = context.obtainStyledAttributes(attrs,
-				R.styleable.SwitchPreference, R.attr.switchPreferenceStyle, 0);
-		setSummaryOn(a.getString(R.styleable.SwitchPreference_summaryOn));
-		setSummaryOff(a.getString(R.styleable.SwitchPreference_summaryOff));
-		setSwitchTextOn(a.getString(R.styleable.SwitchPreference_switchTextOn));
+				R.styleable.SwitchPreference, R.attr.asb_switchPreferenceStyle, 0);
+		setSummaryOn(a.getString(R.styleable.SwitchPreference_asb_summaryOn));
+		setSummaryOff(a.getString(R.styleable.SwitchPreference_asb_summaryOff));
+		setSwitchTextOn(a.getString(R.styleable.SwitchPreference_asb_switchTextOn));
 		setSwitchTextOff(a
-				.getString(R.styleable.SwitchPreference_switchTextOff));
+				.getString(R.styleable.SwitchPreference_asb_switchTextOff));
 		setDisableDependentsState(a.getBoolean(
-				R.styleable.SwitchPreference_disableDependentsState, false));
+				R.styleable.SwitchPreference_asb_disableDependentsState, false));
 		a.recycle();
 	}
 
@@ -100,7 +100,7 @@ public class SwitchPreference extends TwoStatePreference {
 	 *            Style attributes that differ from the default
 	 */
 	public SwitchPreference(Context context, AttributeSet attrs) {
-		this(context, attrs, R.attr.switchPreferenceStyle);
+		this(context, attrs, R.attr.asb_switchPreferenceStyle);
 	}
 
 	/**

--- a/sample/res/values-v11/themes.xml
+++ b/sample/res/values-v11/themes.xml
@@ -25,8 +25,8 @@
 <resources>
 
     <style name="Theme" parent="@android:style/Theme.Holo">
-        <item name="switchStyle">@style/Widget.Holo.CompoundButton.Switch</item>
-        <item name="switchPreferenceStyle">@style/Preference.SwitchPreference</item>
+        <item name="asb_switchStyle">@style/Widget.Holo.CompoundButton.Switch</item>
+        <item name="asb_switchPreferenceStyle">@style/Preference.SwitchPreference</item>
     </style>
 
 </resources>

--- a/sample/res/values/themes.xml
+++ b/sample/res/values/themes.xml
@@ -25,8 +25,8 @@
 <resources>
 
     <style name="Theme" parent="@android:style/Theme">
-        <item name="switchStyle">@style/Widget.Holo.CompoundButton.Switch</item>
-        <item name="switchPreferenceStyle">@style/Preference.SwitchPreference</item>
+        <item name="asb_switchStyle">@style/Widget.Holo.CompoundButton.Switch</item>
+        <item name="asb_switchPreferenceStyle">@style/Preference.SwitchPreference</item>
     </style>
 
 </resources>

--- a/sample/res/xml/preferences.xml
+++ b/sample/res/xml/preferences.xml
@@ -27,7 +27,7 @@
     <org.jraf.android.backport.switchwidget.SwitchPreference
         android:key="testKey"
         android:title="SwitchPreference Test"
-        switchpref:summaryOff="@string/summary_off"
-        switchpref:summaryOn="@string/summary_on" />
+        switchpref:asb_summaryOff="@string/summary_off"
+        switchpref:asb_summaryOn="@string/summary_on" />
 
 </PreferenceScreen>


### PR DESCRIPTION
I didn't test this much beyond the sample app and my own app, but it worked for me and resolved the attribute collisions with the v7 appcompat library 21.0.0 (and other libraries) as described in issue #42. Unfortunately, this is not a backwards-compatible change so you may want to put a warning at the top of the README and increment the major version number if you choose to merge.
